### PR TITLE
Fix render layer logic bug 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn single_bit_should_map_to_correct_index() {
+	fn single_bit_should_map_correctly() {
 		// Arrange
 		let input = RenderLayer::GIZMO3;
 
@@ -281,7 +281,7 @@ mod tests {
 	}
 
 	#[test]
-	fn mixed_bits_should_map_to_correct_indices() {
+	fn mixed_bits_should_map_correctly() {
 		// Arrange
 		let input = RenderLayer::DEFAULT | RenderLayer::GIZMO3;
 


### PR DESCRIPTION
As mentioned and explained in [discord](https://discord.com/channels/1468652482170327042/1468652482962919476/1471512878963101862), this was/is a logic bug and kinda undefined behavior. You can verify it by re-adding the old impl and running `cargo test`:

```rust
RenderLayers::from_iter(layer.iter().map(|l| (l.bits() >> 1) as usize))
```

This implementation should work for any bitmask and is effectively a bit counting implementation (`Kernighan’s algorithm`), which works by iteratively removing the rightmost set bit.