### PR TITLE
Revert "Few small dialogue nits (#87)"

### DIFF
--- a/assets/dialogue/day_two_crt.yarn
+++ b/assets/dialogue/day_two_crt.yarn
@@ -56,7 +56,8 @@ title: Day2CRT
   <<complete_objective "work_2">>
   <<llmanager_emote "point">>
   LLManager: Note this is the second day requiring an unscheduled productivity buffer. #line:16091743
-  LLManager: Any further incidents will result in relocation to our trauma department. $LOCATION_SCUNTHORPE$. #line:16120215
+  LLManager: Any further incidents will result in relocation to our disciplinary center $LOCATION_SCUNTHORPE$. #line:16120215
+  <<llmanager_emote "off">>
 
 <<elseif get_current_objective() == "work_3">>
   <<llmanager_emote "smile">>

--- a/assets/dialogue/day_two_npc.yarn
+++ b/assets/dialogue/day_two_npc.yarn
@@ -1,52 +1,51 @@
 title: D2Npc2
 ---
-Jannet: The office is much lonelier than usual. #line:12510488
-Jannet: But I don't mind. #line:16098898
-Jannet: I talked to LLManager and they agreed to let me start estrogen. #line:10191732
-Jannet: My productivity is through the roof. #line:11798594
-Jannet: I am happy.
+Jannet: The office is much lonelier than usual. #line:12510488 
+Jannet: But I don't mind. #line:16098898 
+Jannet: I allowed myself to be me. #line:10191732 
+Jannet: I'm happy. #line:11798594 
 ===
 
 title: D2Npc3
 ---
-Janitor: John got the fever. #line:8061815
-Janitor: I miss him too. #line:3651679
-Janitor: Will I be missed? #line:1573424
+Janitor: John got the fever. #line:8061815 
+Janitor: I miss him too. #line:3651679 
+Janitor: Will I be missed? #line:1573424 
 ===
 
 title: D2Npc4
 ---
-Janissary: I'm a bit shy about the generator being so close to me. #line:13927065
-Janissary: I mean, generator? I hardly know her. #line:12216199
+Janissary: I'm a bit shy about the generator being so close to me. #line:13927065 
+Janissary: I mean, generator? I hardly know her. #line:12216199 
 ===
 
 title: D2Npc5
 ---
-Janibal Lectern: Did you know that instead of doing drugs, you could consume Pepsi? #line:4863241
-Janibal Lectern: You should consider it. It is the only drink. #line:4232730
-Janibal Lectern: How is my propaganda improving? #line:1997580
+Janibal Lectern: Did you know that instead of doing drugs, you could consume Pepsi? #line:4863241 
+Janibal Lectern: You should consider it. It is the only drink. #line:4232730 
+Janibal Lectern: How is my propaganda improving? #line:1997580 
 ===
 
 title: D2Npc6
 ---
-Jannick: My birthday is over. #line:7584525
-Jannick: My workday isn't. I'm still here. #line:10090132
-Jannick: ... #line:2374192
-Jannick: Thanks for remembering me. #line:6442536
+Jannick: My birthday is over. #line:7584525 
+Jannick: My workday isn't. I'm still here. #line:10090132 
+Jannick: ... #line:2374192 
+Jannick: Thanks for remembering me. #line:6442536 
 ===
 
 
 title: D2Npc10
 ---
-Jandice: I swear, I don't have a problem with alcohol. #line:13307224
-Jandice: But I do without. #line:6521554
+Jandice: I swear, I don't have a problem with alcohol. #line:13307224 
+Jandice: But I do without. #line:6521554 
 ===
 
 title: D2Npc11
 ---
-Janateer: Janissary thinks the machine is a generator. #line:16412261
-Janateer: Fool that he is. #line:3548202
-Janateer: The machine is something much bigger than us all. #line:3792523
+Janateer: Janissary thinks the machine is a generator. #line:16412261 
+Janateer: Fool that he is. #line:3548202 
+Janateer: The machine is something much bigger than us all. #line:3792523 
 ===
 
 title: D2NpcHint


### PR DESCRIPTION
This reverts commit c0186676498a940522634944666f2f8dec2610ee.

Locally running `cargo run --release` crashes with:

```
thread 'Compute Task Pool (17)' (588324) panicked at vendor\bevy_yarnspinner\src\utils.rs:7:9:
Error in Yarn Spinner plugin: Failed to compile Yarn files: Localization mode is on, but "day_two_npc.yarn" is not does not have full line IDs. Cannot generate the line IDs automatically either because we are not in `DevelopmentFileGeneration::Full`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `Pipe(bevy_yarnspinner::project::compilation::compile_loaded_yarn_files, bevy_yarnspinner::utils::panic_on_err)`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

after reverting it works again