### PR TITLE
fix title -> reload level panic

### DIFF
--- a/src/screens/loading/spawn_level.rs
+++ b/src/screens/loading/spawn_level.rs
@@ -5,8 +5,8 @@ use bevy_feronia::prelude::{HeightMapState, ScatterRoot, ScatterState};
 use bevy_landmass::{NavMesh, coords::ThreeD};
 
 use super::LoadingScreen;
-use crate::gameplay::level::{CurrentLevel, spawn_landscape, spawn_level};
 use crate::font::VARIABLE_FONT;
+use crate::gameplay::level::{CurrentLevel, spawn_landscape, spawn_level};
 use crate::scatter::ScatterDone;
 use crate::theme::palette::HEADER_TEXT;
 use crate::{


### PR DESCRIPTION
- the `default` changes are effectively the same underlying code but makes more sense for a reset and might be more maintainable.
- fixes panic  by resetting `CurrentLevel`. It happens when exiting to title menu and reloading into level 1

Can't use `OnExit(Screen::Gameplay)` for it since that happens in between levels too.