### PR TITLE
Fix advancing to next level after first load

### DIFF
--- a/src/screens/loading/preload_assets.rs
+++ b/src/screens/loading/preload_assets.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 use super::LoadingScreen;
 use crate::font::VARIABLE_FONT;
-use crate::gameplay::level::{AdvanceLevel, CurrentLevel};
+use crate::gameplay::level::CurrentLevel;
 use crate::theme::palette::HEADER_TEXT;
 use crate::{asset_tracking::ResourceHandles, theme::prelude::*};
 
@@ -41,7 +41,6 @@ fn spawn_or_skip_asset_loading_screen(
 		if *shaders_compiled {
 			debug!("Skipping shader compilation...");
 			next_screen.set(LoadingScreen::Level);
-			cmd.trigger(AdvanceLevel);
 			return;
 		}
 		debug!("Compiling shaders...");


### PR DESCRIPTION
Currently, if shaders have already been compiled when entering a level, we advance the level for some reason. For example, menu -> day 1 -> menu -> skip day 1, go to day 2. This shouldn't happen!